### PR TITLE
Use builtin bool type instead numpy.*

### DIFF
--- a/common/io.py
+++ b/common/io.py
@@ -45,7 +45,7 @@ def set_vals(geom, vals, attr='co'):
     geom.data.update()
 
 
-def get_scalars(geom, attr='select', dtype=np.bool):
+def get_scalars(geom, attr='select', dtype=bool):
     """
     Return Boolean values of a Blender property collection
     as a numpy array.

--- a/common/sample.py
+++ b/common/sample.py
@@ -33,7 +33,7 @@ def sample_mesh(mesh, samplecnt=1024, mask=None):
     bob.from_mesh(mesh, face_normals=False)
     if mask is not None:
         bfaces = np.array(bob.faces)
-        invmask = np.ones(len(bfaces), dtype=np.bool)
+        invmask = np.ones(len(bfaces), dtype=bool)
         invmask[mask] = False
         bm.ops.delete(bob, geom=bfaces[invmask], context='FACES')
         del bfaces, invmask

--- a/ops/remove_empty_vertex_groups.py
+++ b/ops/remove_empty_vertex_groups.py
@@ -47,11 +47,11 @@ class RemoveEmptyVertexGroups(bpy.types.Operator):
             vgs = o.vertex_groups
             # Bool array storing True at each vertex group's index which
             # is going to be removed
-            to_remov = np.ones(len(vgs), np.bool)
+            to_remov = np.ones(len(vgs), bool)
 
             for v in o.data.vertices:
                 gindcs  = get_scalars(v.groups, 'group',  np.int8)
-                weights = get_scalars(v.groups, 'weight', np.float)
+                weights = get_scalars(v.groups, 'weight', float)
                 # Unset every group for which vertex v has a weight
                 # bigger than the threshold
                 to_remov[gindcs[weights > self.threshold]] = False

--- a/ops/select_visible.py
+++ b/ops/select_visible.py
@@ -132,7 +132,7 @@ class SelectVisible(bpy.types.Operator):
                 )
 
         # Render the objects from several views and mark seen vertices
-        visibl = np.zeros(len(verts), dtype=np.bool)
+        visibl = np.zeros(len(verts), dtype=bool)
         for _ in range(self.samplecnt):
             # Generate random points on the chosen domain from which
             # to render the objects


### PR DESCRIPTION
Use builtin types instead numpy.*

The usage of numpy aliases of builtin types has been deprecated with numpy 1.20.0. This commit replaces the usage of numpy.bool numpy.float with pythons builtin types.
For further information see:

https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations